### PR TITLE
If statements in R version 4.2.0

### DIFF
--- a/R/TreeStructs_methods.r
+++ b/R/TreeStructs_methods.r
@@ -594,7 +594,7 @@ make_convhull.default <- function(ts, trees_not_branches) {
     }, error=function(e){cat("ERROR :",conditionMessage(e), "\n")})
 
     # if crown has too few points to make convhull, then treat as undefined
-    if (is.na(this_convhull)) crown_defined = F
+    if (any(is.na(this_convhull))) crown_defined = F
 
     return(list(convhull = this_convhull,
                 convhull2d = this_2dconvhull,


### PR DESCRIPTION
In [line 597 of TreeStructs_methods.r](https://github.com/ashenkin/treestruct/blob/91508d21fea34323341d700a502a9558bf866215/R/TreeStructs_methods.r#L597), there is an if statement checking whether this_convhull is NA. The variable this_convhull is the result of geometry::convhulln with options = "FA", which is a vector of values. As a result, the if statement has a condition with multiple values, which [raises an error since R version 4.2.0](https://www.r-bloggers.com/2022/04/new-features-in-r-4-2-0/).

I have added an “any”, which mirrors the pre-4.2.0 behaviour. Still, an “all” might be preferable and there might be other similar cases throughout the package. I have not re-built the package at this stage.